### PR TITLE
Fix items not shown

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -280,6 +280,13 @@ fn setup_in_game(
     commands.insert_resource(TrailTexture {
         image_handle: texture_handle,
     });
+    commands.spawn((
+        Mesh2d(meshes.add(Rectangle::default())),
+        MeshMaterial2d(materials.add(Color::from(BLACK))),
+        Transform::default()
+            .with_scale(Vec3::splat(2.))
+            .with_translation(Vec3::new(0., 0., -10.)),
+    ));
 
     if settings.number_of_players >= 1 {
         spawn_player(

--- a/src/main.rs
+++ b/src/main.rs
@@ -532,10 +532,8 @@ fn game_logic(
         for vec in get_collision_points(transform.translation, player.dir) {
             if let Some((x, y)) = game_to_texture_coord(vec, size) {
                 let index = (y * size + x) * 4; // RGBA
-                if texture.data[index] != 0
-                    || texture.data[index + 1] != 0
-                    || texture.data[index + 2] != 0
-                {
+                let alpha = texture.data[index + 3];
+                if alpha != 0 {
                     // something was hit
                     player.alive = false;
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -261,9 +261,7 @@ fn setup_in_game(
             depth_or_array_layers: 1,
         },
         TextureDimension::D2,
-        &(0..(texture_size * texture_size * 4))
-            .map(|i| if i % 4 == 3 { 0xff } else { 0 })
-            .collect::<Vec<_>>(),
+        &vec![0x00; (texture_size * texture_size * 4) as usize],
         TextureFormat::Rgba8UnormSrgb,
         RenderAssetUsages::RENDER_WORLD | RenderAssetUsages::MAIN_WORLD,
     );


### PR DESCRIPTION
When making the background of the trail texture black, it was forgotten that items are supposed to be shown behind the trails. So, the items are behind the trail texture, and if that is black by default, they cannot be seen.
This PR reverts the texture back to transparent and adds a black background texture behind everything else in the scene.