### PR TITLE
ci: use newest deploy-pages actions

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -47,4 +47,4 @@ jobs:
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
deploy-pages v2 cannot find the uploaded artifact, on the github readme of upload-pages-artifact it shows it working with v4